### PR TITLE
Fix rate limiting header

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -83,7 +83,7 @@ class Request {
 
         // If the API limit has been reached
         if (res.statusCode === 429) {
-          const timeToWait = res.headers['x-retry-after'];
+          const timeToWait = res.headers['X-Rate-Limit-Time-Reset-Ms'];
 
           if (this.failOnLimitReached) {
             const err = new Error(`You have reached the rate limit for the BigCommerce API. Please retry in ${timeToWait} seconds.`);
@@ -100,7 +100,7 @@ class Request {
             this.run(method, path, data)
               .then(resolve)
               .catch(reject);
-          }, timeToWait * 1000);
+          }, timeToWait );
         }
 
         res.on('data', chunk => body += chunk);


### PR DESCRIPTION
## What?
Fix the rate limiting header used to determine how much time remains in the current rate limiting window, which is useful for understanding how long you must wait before resuming requests. This was using the the wrong header name.

@bigcommerce/api-client-developers
